### PR TITLE
Fixed build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '28.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
At a `compileSdkVersion 27`,

we'll get errors such as these, as these APIs require v28
- error: resource android:attr/dialogCornerRadius
- fontVariationSettings
- ttcIndex